### PR TITLE
Determining projects to restore...

### DIFF
--- a/DevopsExperiments.API/DevopsExperiments.API.csproj
+++ b/DevopsExperiments.API/DevopsExperiments.API.csproj
@@ -5,6 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <DestinationFolder>/var/www/html/DevopsExperiments/DevopsExperiments.API</DestinationFolder>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DevopsExperiments.Tests/DevopsExperiments.Tests.csproj
+++ b/DevopsExperiments.Tests/DevopsExperiments.Tests.csproj
@@ -8,6 +8,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
+    <DestinationFolder>/var/www/html/DevopsExperiments/DevopsExperiments.Tests</DestinationFolder>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
  All projects are up-to-date for restore.
  DevopsExperiments.API -> /var/www/html/DevopsExperiments/DevopsExperiments.API/bin/Release/net6.0/DevopsExperiments.API.dll
/usr/lib/dotnet/sdk/6.0.116/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Publish.targets(277,5): error MSB3024: Could not copy the file "/var/www/html/DevopsExperiments/DevopsExperiments.API/obj/Release/net6.0/apphost" to the destination file "/var/www/html/DevopsExperiments/DevopsExperiments.API", because the destination is a folder instead of a file. To copy the source file into a folder, consider using the DestinationFolder parameter instead of DestinationFiles. [/var/www/html/DevopsExperiments/DevopsExperiments.API/DevopsExperiments.API.csproj] O erro indica que a cópia do arquivo apphost não pôde ser feita para o destino correto, que é um diretório, não um arquivo. Isso pode ocorrer quando a propriedade DestinationFolder não é especificada.

Para corrigir o erro, adicionar a propriedade DestinationFolder no arquivo DevopsExperiments.API.csproj.