### PR TITLE
Quando o parâmetro UseAppHost é definido como false, o arquivo apphos…

### DIFF
--- a/DevopsExperiments.API/DevopsExperiments.API.csproj
+++ b/DevopsExperiments.API/DevopsExperiments.API.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <DestinationFolder>/var/www/html/DevopsExperiments/DevopsExperiments.API</DestinationFolder>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DevopsExperiments.Tests/DevopsExperiments.Tests.csproj
+++ b/DevopsExperiments.Tests/DevopsExperiments.Tests.csproj
@@ -8,7 +8,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <DestinationFolder>/var/www/html/DevopsExperiments/DevopsExperiments.Tests</DestinationFolder>
+    <UseAppHost>false</UseAppHost>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
…t não será criado e, portanto, o erro de cópia pode ser resolvido.